### PR TITLE
deck 9.2 compatibility update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ecoscope/ecoscope-deck-widgets",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ecoscope/ecoscope-deck-widgets",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-to-image": "^1.11.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ecoscope/ecoscope-deck-widgets",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ecoscope/ecoscope-deck-widgets",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-to-image": "^1.11.13",
@@ -15,28 +15,28 @@
         "ts-loader": "^9.5.2"
       },
       "devDependencies": {
-        "@deck.gl/core": "^9.1.14",
-        "@deck.gl/geo-layers": "^9.1.14",
-        "@deck.gl/layers": "^9.1.14",
-        "@deck.gl/widgets": "^9.1.14",
+        "@deck.gl/core": "^9.2.1",
+        "@deck.gl/geo-layers": "^9.2.1",
+        "@deck.gl/layers": "^9.2.1",
+        "@deck.gl/widgets": "^9.2.1",
         "css-loader": "^7.1.2",
         "style-loader": "^4.0.0",
         "webpack-cli": "^6.0.1"
       }
     },
     "node_modules/@deck.gl/core": {
-      "version": "9.1.14",
-      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.1.14.tgz",
-      "integrity": "sha512-tXakSSvi5g+EvxSsnnjoRO8z3XxHxISTRzzIqcs3AZuWHnDptK28y9iD0Da21ILop1IYLaWE1QTUe6IAdp/Wag==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@deck.gl/core/-/core-9.2.1.tgz",
+      "integrity": "sha512-7aQ0jy/T5qc9Llr80XC5OQ/KDA38T0qi68QXuXEy5lZCrOyI4V0wZXgolHylEYisDB5fs+YTTKnzhOp9hrA9xg==",
       "dev": true,
       "dependencies": {
         "@loaders.gl/core": "^4.2.0",
         "@loaders.gl/images": "^4.2.0",
-        "@luma.gl/constants": "~9.1.9",
-        "@luma.gl/core": "~9.1.9",
-        "@luma.gl/engine": "~9.1.9",
-        "@luma.gl/shadertools": "~9.1.9",
-        "@luma.gl/webgl": "~9.1.9",
+        "@luma.gl/constants": "^9.2.2",
+        "@luma.gl/core": "^9.2.2",
+        "@luma.gl/engine": "^9.2.2",
+        "@luma.gl/shadertools": "^9.2.2",
+        "@luma.gl/webgl": "^9.2.2",
         "@math.gl/core": "^4.1.0",
         "@math.gl/sun": "^4.1.0",
         "@math.gl/types": "^4.1.0",
@@ -50,26 +50,26 @@
       }
     },
     "node_modules/@deck.gl/extensions": {
-      "version": "9.1.14",
-      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.1.14.tgz",
-      "integrity": "sha512-uPm9Ye/XD8YAYNxT1G6HxyIOBxa2+MBdGLyqobQj3pCnkO/YtgY/fi/BjM+eVOBXX+keBrXEclEvB0Add5eS8Q==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@deck.gl/extensions/-/extensions-9.2.1.tgz",
+      "integrity": "sha512-bajeogSxX2GgloH7RIDK4YsY+2bj414593UfJzZW0Ol9w1xvLvR4SKE7CgctBW+EMZPJYgJfPth9ti2Q7xGlFQ==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@luma.gl/constants": "~9.1.9",
-        "@luma.gl/shadertools": "~9.1.9",
+        "@luma.gl/constants": "^9.2.2",
+        "@luma.gl/shadertools": "^9.2.2",
         "@math.gl/core": "^4.1.0"
       },
       "peerDependencies": {
         "@deck.gl/core": "^9.1.0",
-        "@luma.gl/core": "~9.1.9",
-        "@luma.gl/engine": "~9.1.9"
+        "@luma.gl/core": "^9.2.2",
+        "@luma.gl/engine": "^9.2.2"
       }
     },
     "node_modules/@deck.gl/geo-layers": {
-      "version": "9.1.14",
-      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.1.14.tgz",
-      "integrity": "sha512-vk/vssJl9mxvPH04EyUFVa+gHedJYo55KrNjUiQWPBgtMyVefF/5M2X09UPXSnL44cMat7ZgX5wR9HMMxAwo+Q==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@deck.gl/geo-layers/-/geo-layers-9.2.1.tgz",
+      "integrity": "sha512-Cq7TZa15c2+XE7uci65AqPSOY/yDicmPjYJxNX/DgvMkgGOYlEO9TmBu8CCqNaBCxJlK9Ztz6mwoKZbltUBGQw==",
       "dev": true,
       "dependencies": {
         "@loaders.gl/3d-tiles": "^4.2.0",
@@ -80,12 +80,13 @@
         "@loaders.gl/terrain": "^4.2.0",
         "@loaders.gl/tiles": "^4.2.0",
         "@loaders.gl/wms": "^4.2.0",
-        "@luma.gl/gltf": "~9.1.9",
-        "@luma.gl/shadertools": "~9.1.9",
+        "@luma.gl/gltf": "^9.2.2",
+        "@luma.gl/shadertools": "^9.2.2",
         "@math.gl/core": "^4.1.0",
         "@math.gl/culling": "^4.1.0",
         "@math.gl/web-mercator": "^4.1.0",
         "@types/geojson": "^7946.0.8",
+        "a5-js": "^0.5.0",
         "h3-js": "^4.1.0",
         "long": "^3.2.0"
       },
@@ -95,19 +96,19 @@
         "@deck.gl/layers": "^9.1.0",
         "@deck.gl/mesh-layers": "^9.1.0",
         "@loaders.gl/core": "^4.2.0",
-        "@luma.gl/core": "~9.1.9",
-        "@luma.gl/engine": "~9.1.9"
+        "@luma.gl/core": "^9.2.2",
+        "@luma.gl/engine": "^9.2.2"
       }
     },
     "node_modules/@deck.gl/layers": {
-      "version": "9.1.14",
-      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.1.14.tgz",
-      "integrity": "sha512-cCClyZxznzXLPJnH2er7ZJAnXYuEHH/0hcDoc5Lp3SNByx3ASNrZcizIBOCxO7132LHFN4cSeyz0JVP8p56TDg==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@deck.gl/layers/-/layers-9.2.1.tgz",
+      "integrity": "sha512-8PuWodigkNJQIdkL2XPwrvP1mD2dOt0WFE3VtVHUt/Vv/mzZ5BeV9M6nt1SADLkV6S5Do8IsC98YuLQ7TRQXEw==",
       "dev": true,
       "dependencies": {
         "@loaders.gl/images": "^4.2.0",
         "@loaders.gl/schema": "^4.2.0",
-        "@luma.gl/shadertools": "~9.1.9",
+        "@luma.gl/shadertools": "^9.2.2",
         "@mapbox/tiny-sdf": "^2.0.5",
         "@math.gl/core": "^4.1.0",
         "@math.gl/polygon": "^4.1.0",
@@ -117,37 +118,41 @@
       "peerDependencies": {
         "@deck.gl/core": "^9.1.0",
         "@loaders.gl/core": "^4.2.0",
-        "@luma.gl/core": "~9.1.9",
-        "@luma.gl/engine": "~9.1.9"
+        "@luma.gl/core": "^9.2.2",
+        "@luma.gl/engine": "^9.2.2"
       }
     },
     "node_modules/@deck.gl/mesh-layers": {
-      "version": "9.1.14",
-      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.1.14.tgz",
-      "integrity": "sha512-NVUw0yG4stJfrklWCGP9j8bNlf9YQc4PccMeNNIHNrU/Je6/Va6dJZg0RGtVkeaTY1Lk3A7wRzq8/M5Urfvuiw==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@deck.gl/mesh-layers/-/mesh-layers-9.2.1.tgz",
+      "integrity": "sha512-uSr0HgkFO8A7g6CDhEvWPieoZQiLUVGmumqVUXj1FqzbiKI5yBsbt839xMxS2ZKZWBdZI7FUp3G+NML1KBGdxw==",
       "dev": true,
       "peer": true,
       "dependencies": {
         "@loaders.gl/gltf": "^4.2.0",
-        "@luma.gl/gltf": "~9.1.9",
-        "@luma.gl/shadertools": "~9.1.9"
+        "@loaders.gl/schema": "^4.2.0",
+        "@luma.gl/gltf": "^9.2.2",
+        "@luma.gl/shadertools": "^9.2.2"
       },
       "peerDependencies": {
         "@deck.gl/core": "^9.1.0",
-        "@luma.gl/core": "~9.1.9",
-        "@luma.gl/engine": "~9.1.9"
+        "@luma.gl/core": "^9.2.2",
+        "@luma.gl/engine": "^9.2.2",
+        "@luma.gl/gltf": "^9.2.2",
+        "@luma.gl/shadertools": "^9.2.2"
       }
     },
     "node_modules/@deck.gl/widgets": {
-      "version": "9.1.14",
-      "resolved": "https://registry.npmjs.org/@deck.gl/widgets/-/widgets-9.1.14.tgz",
-      "integrity": "sha512-hEyvvrqxEr7ujqTyTbdm5VTwY4oMYKNsLyXKjxWerHCIyfT971UYyV4cbILqvYf+L8spE146NFqwx0jj1bBqWw==",
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@deck.gl/widgets/-/widgets-9.2.1.tgz",
+      "integrity": "sha512-0qoykxCScX8HbCOFRX9T1jCUPo+qd5keOK5cumFn+fU5erEs9+WN07guEfzlx0uEVSI3Q08n7Mfnzs8yXOPFAQ==",
       "dev": true,
       "dependencies": {
         "preact": "^10.17.0"
       },
       "peerDependencies": {
-        "@deck.gl/core": "^9.1.0"
+        "@deck.gl/core": "^9.1.0",
+        "@luma.gl/core": "^9.1.9"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -160,17 +165,13 @@
       }
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
-      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
       "peer": true,
       "dependencies": {
-        "@jridgewell/set-array": "^1.2.1",
-        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -182,19 +183,10 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/@jridgewell/set-array": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
-      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
-      "peer": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/source-map": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
-      "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
+      "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
       "peer": true,
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
@@ -202,15 +194,15 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "peer": true
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
       "peer": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -238,42 +230,6 @@
         "@probe.gl/log": "^4.0.4",
         "long": "^5.2.1"
       },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/3d-tiles/node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
-      "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
-      "dev": true,
-      "dependencies": {
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/3d-tiles/node_modules/@loaders.gl/schema": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
-      "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
-      "dev": true,
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/3d-tiles/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
-      "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
-      "dev": true,
       "peerDependencies": {
         "@loaders.gl/core": "^4.3.0"
       }
@@ -308,51 +264,15 @@
         "@loaders.gl/core": "^4.3.0"
       }
     },
-    "node_modules/@loaders.gl/compression/node_modules/@loaders.gl/loader-utils": {
+    "node_modules/@loaders.gl/core": {
       "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
-      "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
+      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-4.3.4.tgz",
+      "integrity": "sha512-cG0C5fMZ1jyW6WCsf4LoHGvaIAJCEVA/ioqKoYRwoSfXkOf+17KupK1OUQyUCw5XoRn+oWA1FulJQOYlXnb9Gw==",
       "dev": true,
       "dependencies": {
+        "@loaders.gl/loader-utils": "4.3.4",
         "@loaders.gl/schema": "4.3.4",
         "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/compression/node_modules/@loaders.gl/schema": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
-      "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
-      "dev": true,
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/compression/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
-      "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
-      "dev": true,
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/core": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/core/-/core-4.3.3.tgz",
-      "integrity": "sha512-RaQ3uNg4ZaVqDRgvJ2CjaOjeeHdKvbKuzFFgbGnflVB9is5bu+h3EKc3Jke7NGVvLBsZ6oIXzkwHijVsMfxv8g==",
-      "dev": true,
-      "dependencies": {
-        "@loaders.gl/loader-utils": "4.3.3",
-        "@loaders.gl/schema": "4.3.3",
-        "@loaders.gl/worker-utils": "4.3.3",
         "@probe.gl/log": "^4.0.2"
       }
     },
@@ -366,42 +286,6 @@
         "@loaders.gl/worker-utils": "4.3.4",
         "@types/crypto-js": "^4.0.2"
       },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/crypto/node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
-      "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
-      "dev": true,
-      "dependencies": {
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/crypto/node_modules/@loaders.gl/schema": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
-      "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
-      "dev": true,
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/crypto/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
-      "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
-      "dev": true,
       "peerDependencies": {
         "@loaders.gl/core": "^4.3.0"
       }
@@ -421,42 +305,6 @@
         "@loaders.gl/core": "^4.3.0"
       }
     },
-    "node_modules/@loaders.gl/draco/node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
-      "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
-      "dev": true,
-      "dependencies": {
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/draco/node_modules/@loaders.gl/schema": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
-      "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
-      "dev": true,
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/draco/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
-      "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
-      "dev": true,
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
     "node_modules/@loaders.gl/gis": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@loaders.gl/gis/-/gis-4.3.4.tgz",
@@ -469,42 +317,6 @@
         "@math.gl/polygon": "^4.1.0",
         "pbf": "^3.2.1"
       },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/gis/node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
-      "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
-      "dev": true,
-      "dependencies": {
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/gis/node_modules/@loaders.gl/schema": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
-      "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
-      "dev": true,
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/gis/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
-      "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
-      "dev": true,
       "peerDependencies": {
         "@loaders.gl/core": "^4.3.0"
       }
@@ -526,42 +338,6 @@
         "@loaders.gl/core": "^4.3.0"
       }
     },
-    "node_modules/@loaders.gl/gltf/node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
-      "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
-      "dev": true,
-      "dependencies": {
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/gltf/node_modules/@loaders.gl/schema": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
-      "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
-      "dev": true,
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/gltf/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
-      "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
-      "dev": true,
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
     "node_modules/@loaders.gl/images": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@loaders.gl/images/-/images-4.3.4.tgz",
@@ -574,7 +350,7 @@
         "@loaders.gl/core": "^4.3.0"
       }
     },
-    "node_modules/@loaders.gl/images/node_modules/@loaders.gl/loader-utils": {
+    "node_modules/@loaders.gl/loader-utils": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
       "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
@@ -582,42 +358,6 @@
       "dependencies": {
         "@loaders.gl/schema": "4.3.4",
         "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/images/node_modules/@loaders.gl/schema": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
-      "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
-      "dev": true,
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/images/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
-      "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
-      "dev": true,
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.3.tgz",
-      "integrity": "sha512-8erUIwWLiIsZX36fFa/seZsfTsWlLk72Sibh/YZJrPAefuVucV4mGGzMBZ96LE2BUfJhadn250eio/59TUFbNw==",
-      "dev": true,
-      "dependencies": {
-        "@loaders.gl/schema": "4.3.3",
-        "@loaders.gl/worker-utils": "4.3.3",
         "@probe.gl/log": "^4.0.2",
         "@probe.gl/stats": "^4.0.2"
       },
@@ -635,42 +375,6 @@
         "@loaders.gl/loader-utils": "4.3.4",
         "@math.gl/core": "^4.1.0"
       },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/math/node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
-      "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
-      "dev": true,
-      "dependencies": {
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/math/node_modules/@loaders.gl/schema": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
-      "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
-      "dev": true,
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/math/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
-      "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
-      "dev": true,
       "peerDependencies": {
         "@loaders.gl/core": "^4.3.0"
       }
@@ -693,46 +397,10 @@
         "@loaders.gl/core": "^4.3.0"
       }
     },
-    "node_modules/@loaders.gl/mvt/node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
-      "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
-      "dev": true,
-      "dependencies": {
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/mvt/node_modules/@loaders.gl/schema": {
+    "node_modules/@loaders.gl/schema": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
       "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
-      "dev": true,
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/mvt/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
-      "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
-      "dev": true,
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/schema": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.3.tgz",
-      "integrity": "sha512-zacc9/8je+VbuC6N/QRfiTjRd+BuxsYlddLX1u5/X/cg9s36WZZBlU1oNKUgTYe8eO6+qLyYx77yi+9JbbEehw==",
       "dev": true,
       "dependencies": {
         "@types/geojson": "^7946.0.7"
@@ -756,42 +424,6 @@
         "@loaders.gl/core": "^4.3.0"
       }
     },
-    "node_modules/@loaders.gl/terrain/node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
-      "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
-      "dev": true,
-      "dependencies": {
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/terrain/node_modules/@loaders.gl/schema": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
-      "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
-      "dev": true,
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/terrain/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
-      "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
-      "dev": true,
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
     "node_modules/@loaders.gl/textures": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@loaders.gl/textures/-/textures-4.3.4.tgz",
@@ -806,42 +438,6 @@
         "ktx-parse": "^0.7.0",
         "texture-compressor": "^1.0.2"
       },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/textures/node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
-      "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
-      "dev": true,
-      "dependencies": {
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/textures/node_modules/@loaders.gl/schema": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
-      "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
-      "dev": true,
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/textures/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
-      "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
-      "dev": true,
       "peerDependencies": {
         "@loaders.gl/core": "^4.3.0"
       }
@@ -864,42 +460,6 @@
         "@loaders.gl/core": "^4.3.0"
       }
     },
-    "node_modules/@loaders.gl/tiles/node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
-      "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
-      "dev": true,
-      "dependencies": {
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/tiles/node_modules/@loaders.gl/schema": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
-      "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
-      "dev": true,
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/tiles/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
-      "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
-      "dev": true,
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
     "node_modules/@loaders.gl/wms": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@loaders.gl/wms/-/wms-4.3.4.tgz",
@@ -917,46 +477,10 @@
         "@loaders.gl/core": "^4.3.0"
       }
     },
-    "node_modules/@loaders.gl/wms/node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
-      "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
-      "dev": true,
-      "dependencies": {
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/wms/node_modules/@loaders.gl/schema": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
-      "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
-      "dev": true,
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/wms/node_modules/@loaders.gl/worker-utils": {
+    "node_modules/@loaders.gl/worker-utils": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
       "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
-      "dev": true,
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.3.tgz",
-      "integrity": "sha512-eg45Ux6xqsAfqPUqJkhmbFZh9qfmYuPfA+34VcLtfeXIwAngeP6o4SrTmm9LWLGUKiSh47anCEV1p7borDgvGQ==",
       "dev": true,
       "peerDependencies": {
         "@loaders.gl/core": "^4.3.0"
@@ -972,42 +496,6 @@
         "@loaders.gl/schema": "4.3.4",
         "fast-xml-parser": "^4.2.5"
       },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/xml/node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
-      "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
-      "dev": true,
-      "dependencies": {
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/xml/node_modules/@loaders.gl/schema": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
-      "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
-      "dev": true,
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/xml/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
-      "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
-      "dev": true,
       "peerDependencies": {
         "@loaders.gl/core": "^4.3.0"
       }
@@ -1028,52 +516,16 @@
         "@loaders.gl/core": "^4.3.0"
       }
     },
-    "node_modules/@loaders.gl/zip/node_modules/@loaders.gl/loader-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/loader-utils/-/loader-utils-4.3.4.tgz",
-      "integrity": "sha512-tjMZvlKQSaMl2qmYTAxg+ySR6zd6hQn5n3XaU8+Ehp90TD3WzxvDKOMNDqOa72fFmIV+KgPhcmIJTpq4lAdC4Q==",
-      "dev": true,
-      "dependencies": {
-        "@loaders.gl/schema": "4.3.4",
-        "@loaders.gl/worker-utils": "4.3.4",
-        "@probe.gl/log": "^4.0.2",
-        "@probe.gl/stats": "^4.0.2"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/zip/node_modules/@loaders.gl/schema": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/schema/-/schema-4.3.4.tgz",
-      "integrity": "sha512-1YTYoatgzr/6JTxqBLwDiD3AVGwQZheYiQwAimWdRBVB0JAzych7s1yBuE0CVEzj4JDPKOzVAz8KnU1TiBvJGw==",
-      "dev": true,
-      "dependencies": {
-        "@types/geojson": "^7946.0.7"
-      },
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
-    "node_modules/@loaders.gl/zip/node_modules/@loaders.gl/worker-utils": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@loaders.gl/worker-utils/-/worker-utils-4.3.4.tgz",
-      "integrity": "sha512-EbsszrASgT85GH3B7jkx7YXfQyIYo/rlobwMx6V3ewETapPUwdSAInv+89flnk5n2eu2Lpdeh+2zS6PvqbL2RA==",
-      "dev": true,
-      "peerDependencies": {
-        "@loaders.gl/core": "^4.3.0"
-      }
-    },
     "node_modules/@luma.gl/constants": {
-      "version": "9.1.9",
-      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-9.1.9.tgz",
-      "integrity": "sha512-yc9fml04OeTTcwK+7gmDMxoLQ67j4ZiAFXjmYvPomYyBVzS0NZxTDuwcCBmnxjLOiroOZW8FRRrVc/yOiFug2w==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@luma.gl/constants/-/constants-9.2.2.tgz",
+      "integrity": "sha512-XURMF0gSh0ImZltYa/PCe9KgmopQJiOA6y1m1PxDxJY8OCLma7ZJyvomLn7TQBvPtWTYZsibTW7blu7RwThsaQ==",
       "dev": true
     },
     "node_modules/@luma.gl/core": {
-      "version": "9.1.9",
-      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-9.1.9.tgz",
-      "integrity": "sha512-1i9N7+I/UbFjx3axSMlc3/NufA+C2iBv/7mw51gRE/ypQPgvFmY/QqXBVZRe+nthF+OhlUMhO19TBndzYFTWhA==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@luma.gl/core/-/core-9.2.2.tgz",
+      "integrity": "sha512-X63BnXXDlC9AmoG4sUVsfxLn+DoNovbX/z5ZXxnhpxx47536Ss/SLzwnLvm/ZoDhK9/s5qdI95mSZKuqzKCkjw==",
       "dev": true,
       "dependencies": {
         "@math.gl/types": "^4.1.0",
@@ -1084,9 +536,9 @@
       }
     },
     "node_modules/@luma.gl/engine": {
-      "version": "9.1.9",
-      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.1.9.tgz",
-      "integrity": "sha512-n1GLK1sUMFkWxdb+aZYn6ZBFltFEMi7X+6ZPxn2pBsNT6oeF4AyvH5AyqhOpvHvUnCLDt3Zsf1UIfx3MI//YSw==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@luma.gl/engine/-/engine-9.2.2.tgz",
+      "integrity": "sha512-Upq/jVPvgi/rjwgSGYyW+jobJBotKR/aNTDwyHAubx6wXWluZqnR0ZBwctiO9i7w2RIzZGboMYs4dIgVw0ULaQ==",
       "dev": true,
       "dependencies": {
         "@math.gl/core": "^4.1.0",
@@ -1095,30 +547,32 @@
         "@probe.gl/stats": "^4.0.8"
       },
       "peerDependencies": {
-        "@luma.gl/core": "^9.1.0",
-        "@luma.gl/shadertools": "^9.1.0"
+        "@luma.gl/core": "~9.2.0",
+        "@luma.gl/shadertools": "~9.2.0"
       }
     },
     "node_modules/@luma.gl/gltf": {
-      "version": "9.1.9",
-      "resolved": "https://registry.npmjs.org/@luma.gl/gltf/-/gltf-9.1.9.tgz",
-      "integrity": "sha512-KgVBIFCtRO1oadgMDycMJA5s+q519l/fQBGAZpUcLfWsaEDQfdHW2NLdrK/00VDv46Ng8tN/O6uyH6E40uLcLw==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@luma.gl/gltf/-/gltf-9.2.2.tgz",
+      "integrity": "sha512-OL5dZlgq99QZCmOAPq4J3wlEmVkDbBdpXlzUukyHqI/1UV1jonb6e41JykXn1WuOYcrtYM8PnygG3MQ8afRjvA==",
       "dev": true,
       "dependencies": {
         "@loaders.gl/core": "^4.2.0",
+        "@loaders.gl/gltf": "^4.2.0",
         "@loaders.gl/textures": "^4.2.0",
         "@math.gl/core": "^4.1.0"
       },
       "peerDependencies": {
-        "@luma.gl/core": "^9.1.0",
-        "@luma.gl/engine": "^9.1.0",
-        "@luma.gl/shadertools": "^9.1.0"
+        "@luma.gl/constants": "~9.2.0",
+        "@luma.gl/core": "~9.2.0",
+        "@luma.gl/engine": "~9.2.0",
+        "@luma.gl/shadertools": "~9.2.0"
       }
     },
     "node_modules/@luma.gl/shadertools": {
-      "version": "9.1.9",
-      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.1.9.tgz",
-      "integrity": "sha512-Uqp2xfgIEunRMLXTeCJ4uEMlWcUGcYMZGJ8GAOrAeDzn4bMKVRKmZDC71vkuTctnaodM3UdrI9W6s1sJlrXsxw==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@luma.gl/shadertools/-/shadertools-9.2.2.tgz",
+      "integrity": "sha512-ChskCXE8Q+5/rC8zPR7pHBSfERGRui5qvw6bZnOZMVwTvGbW5tI5od5Wu9ytGi45kWus66M+M/o5LpP3hfc4Hg==",
       "dev": true,
       "dependencies": {
         "@math.gl/core": "^4.1.0",
@@ -1126,21 +580,21 @@
         "wgsl_reflect": "^1.2.0"
       },
       "peerDependencies": {
-        "@luma.gl/core": "^9.1.0"
+        "@luma.gl/core": "~9.2.0"
       }
     },
     "node_modules/@luma.gl/webgl": {
-      "version": "9.1.9",
-      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-9.1.9.tgz",
-      "integrity": "sha512-jecHjhNSWkXH0v62rM6G5fIIkOmsrND27099iKgdutFvHIvd4QS4UzGWEEa9AEPlP0rTLqXkA6y6YL7f42ZkVg==",
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/@luma.gl/webgl/-/webgl-9.2.2.tgz",
+      "integrity": "sha512-6g1UWpa61teUDju6gf8hRj4Z/vh4HKscO1FBkZRW/N4AimjXf0wDYwE20m0tD1u6ZRiUORkqVAoMPf8CyMfU/g==",
       "dev": true,
       "dependencies": {
-        "@luma.gl/constants": "9.1.9",
+        "@luma.gl/constants": "9.2.2",
         "@math.gl/types": "^4.1.0",
         "@probe.gl/env": "^4.0.8"
       },
       "peerDependencies": {
-        "@luma.gl/core": "^9.1.0"
+        "@luma.gl/core": "~9.2.0"
       }
     },
     "node_modules/@mapbox/martini": {
@@ -1360,11 +814,11 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "24.0.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.3.tgz",
-      "integrity": "sha512-R4I/kzCYAdRLzfiCabn9hxWfbuHS573x+r0dJMkkzThEa7pbrcDWK+9zu3e7aBOouf+rQAciqPFMnxwr0aWgKg==",
+      "version": "24.7.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.7.1.tgz",
+      "integrity": "sha512-CmyhGZanP88uuC5GpWU9q+fI61j2SkhO3UGMUdfYRE6Bcy0ccyzn1Rqj9YAB/ZY4kOXmNf0ocah5GtphmLMP6Q==",
       "dependencies": {
-        "undici-types": "~7.8.0"
+        "undici-types": "~7.14.0"
       }
     },
     "node_modules/@types/offscreencanvas": {
@@ -1581,6 +1035,15 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "peer": true
     },
+    "node_modules/a5-js": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/a5-js/-/a5-js-0.5.0.tgz",
+      "integrity": "sha512-VAw19sWdYadhdovb0ViOIi1SdKx6H6LwcGMRFKwMfgL5gcmL/1fKJHfgsNgNaJ7xC/eEyjs6VK+VVd4N0a+peg==",
+      "dev": true,
+      "dependencies": {
+        "gl-matrix": "^3.4.3"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1591,6 +1054,18 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-import-phases": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
+      "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
+      "peer": true,
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
       }
     },
     "node_modules/ajv": {
@@ -1682,6 +1157,15 @@
       ],
       "optional": true
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.16",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.16.tgz",
+      "integrity": "sha512-OMu3BGQ4E7P1ErFsIPpbJh0qvDudM/UuJeHgkAvfWe+0HFJCXh+t/l8L6fVLR55RI/UbKrVLnAXZSVwd9ysWYw==",
+      "peer": true,
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -1704,9 +1188,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
-      "integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
+      "version": "4.26.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.3.tgz",
+      "integrity": "sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==",
       "funding": [
         {
           "type": "opencollective",
@@ -1723,9 +1207,10 @@
       ],
       "peer": true,
       "dependencies": {
-        "caniuse-lite": "^1.0.30001718",
-        "electron-to-chromium": "^1.5.160",
-        "node-releases": "^2.0.19",
+        "baseline-browser-mapping": "^2.8.9",
+        "caniuse-lite": "^1.0.30001746",
+        "electron-to-chromium": "^1.5.227",
+        "node-releases": "^2.0.21",
         "update-browserslist-db": "^1.1.3"
       },
       "bin": {
@@ -1751,9 +1236,9 @@
       "peer": true
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001723",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001723.tgz",
-      "integrity": "sha512-1R/elMjtehrFejxwmexeXAtae5UO9iSyFn6G/I806CYC/BLyyBk1EPhrKBkWhy6wM6Xnm47dSJQec+tLJ39WHw==",
+      "version": "1.0.30001749",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001749.tgz",
+      "integrity": "sha512-0rw2fJOmLfnzCRbkm8EyHL8SvI2Apu5UbnQuTsJ0ClgrH8hcwFooJ1s5R0EP8o8aVrFu8++ae29Kt9/gZAZp/Q==",
       "funding": [
         {
           "type": "opencollective",
@@ -1783,17 +1268,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/chalk/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/charenc": {
@@ -1970,15 +1444,15 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.170",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.170.tgz",
-      "integrity": "sha512-GP+M7aeluQo9uAyiTCxgIj/j+PrWhMlY7LFVj8prlsPljd0Fdg9AprlfUi+OCSFWy9Y5/2D/Jrj9HS8Z4rpKWA==",
+      "version": "1.5.234",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.234.tgz",
+      "integrity": "sha512-RXfEp2x+VRYn8jbKfQlRImzoJU01kyDvVPBmG39eU2iuRVhuS6vQNocB8J0/8GrIMLnPzgz4eW6WiRnJkTuNWg==",
       "peer": true
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.18.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.1.tgz",
-      "integrity": "sha512-ZSW3ma5GkcQBIpwZTSRAI8N71Uuwgs93IezB7mf7R60tC8ZbJideoDNKjHn2O9KIlx6rkGTTEk1xUCK2E1Y2Yg==",
+      "version": "5.18.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.3.tgz",
+      "integrity": "sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -1988,9 +1462,9 @@
       }
     },
     "node_modules/envinfo": {
-      "version": "7.14.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
-      "integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.17.0.tgz",
+      "integrity": "sha512-GpfViocsFM7viwClFgxK26OtjMlKN67GCR5v6ASFkotxtpBWd9d+vNy+AH7F2E1TUkMDZ8P/dDPZX71/NG8xnQ==",
       "dev": true,
       "bin": {
         "envinfo": "dist/cli.js"
@@ -2073,9 +1547,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
       "funding": [
         {
           "type": "github",
@@ -2164,9 +1638,9 @@
       }
     },
     "node_modules/gl-matrix": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.3.tgz",
-      "integrity": "sha512-wcCp8vu8FT22BnvKVPjXa/ICBWRq/zjFfdofZy1WSpQZpphblv12/bOQLBC1rMM7SGOFS9ltVmKOHil5+Ml7gA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
       "dev": true
     },
     "node_modules/glob-to-regexp": {
@@ -2382,6 +1856,21 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/jest-worker/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "peer": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/json-parse-even-better-errors": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -2431,12 +1920,16 @@
       }
     },
     "node_modules/loader-runner": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
-      "integrity": "sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.1.tgz",
+      "integrity": "sha512-IWqP2SCPhyVFTBtRcgMHdzlf9ul25NwaFx4wCEH/KjAXuuHY4yNjvPXsBokp8jCB936PyWRaPKUNh8NvylLp2Q==",
       "peer": true,
       "engines": {
         "node": ">=6.11.5"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/locate-path": {
@@ -2502,17 +1995,6 @@
         "node": ">=8.6"
       }
     },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -2565,9 +2047,9 @@
       "peer": true
     },
     "node_modules/node-releases": {
-      "version": "2.0.19",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
-      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "version": "2.0.23",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.23.tgz",
+      "integrity": "sha512-cCmFDMSm26S6tQSDpBCg/NR8NENrVPhAJSf+XbxBG4rPFaaonlEoE9wHQmun+cls499TQGSb7ZyPBRlzgKfpeg==",
       "peer": true
     },
     "node_modules/p-limit": {
@@ -2653,6 +2135,17 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
@@ -2773,9 +2266,9 @@
       "dev": true
     },
     "node_modules/preact": {
-      "version": "10.26.9",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.9.tgz",
-      "integrity": "sha512-SSjF9vcnF27mJK1XyFMNJzFd5u3pQiATFqoaDy03XuN00u4ziveVVEGt5RKJrDR8MHE/wJo9Nnad56RLzS2RMA==",
+      "version": "10.27.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.2.tgz",
+      "integrity": "sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -2824,12 +2317,6 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
-    },
-    "node_modules/readable-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
     },
     "node_modules/rechoir": {
       "version": "0.8.0",
@@ -2903,29 +2390,14 @@
       }
     },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "peer": true
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/schema-utils": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-      "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
       "peer": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
@@ -2942,9 +2414,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -3007,12 +2479,11 @@
       "dev": true
     },
     "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "peer": true,
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">= 12"
       }
     },
     "node_modules/source-map-js": {
@@ -3034,6 +2505,15 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/source-map-support/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -3048,12 +2528,6 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
-    },
-    "node_modules/string_decoder/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true
     },
     "node_modules/strnum": {
       "version": "1.1.2",
@@ -3084,18 +2558,14 @@
       }
     },
     "node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "peer": true,
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {
@@ -3111,21 +2581,25 @@
       }
     },
     "node_modules/tapable": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.2.2.tgz",
-      "integrity": "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
+      "integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/terser": {
-      "version": "5.43.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
-      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.0.tgz",
+      "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
       "peer": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },
@@ -3195,9 +2669,9 @@
       }
     },
     "node_modules/ts-loader": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.2.tgz",
-      "integrity": "sha512-Qo4piXvOTWcMGIgRiuFa6nHNm+54HbYaZCKqc9eeZCLRy3XqafQgwX2F7mofrbJG3g7EEb+lkiR+z2Lic2s3Zw==",
+      "version": "9.5.4",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-9.5.4.tgz",
+      "integrity": "sha512-nCz0rEwunlTZiy6rXFByQU1kVVpCIgUpc/psFiKVrUwrizdnIbRFu8w7bxhUF0X613DYwT4XzrZHpVyMe758hQ==",
       "dependencies": {
         "chalk": "^4.1.0",
         "enhanced-resolve": "^5.0.0",
@@ -3213,18 +2687,10 @@
         "webpack": "^5.0.0"
       }
     },
-    "node_modules/ts-loader/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3235,9 +2701,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw=="
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.14.0.tgz",
+      "integrity": "sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA=="
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.3",
@@ -3289,21 +2755,22 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.99.9",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.99.9.tgz",
-      "integrity": "sha512-brOPwM3JnmOa+7kd3NsmOUOwbDAj8FT9xDsG3IW0MgbN9yZV7Oi/s/+MNQ/EcSMqw7qfoRyXPoeEWT8zLVdVGg==",
+      "version": "5.102.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.102.1.tgz",
+      "integrity": "sha512-7h/weGm9d/ywQ6qzJ+Xy+r9n/3qgp/thalBbpOi5i223dPXKi04IBtqPN9nTd+jBc7QKfvDbaBnFipYp4sJAUQ==",
       "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
-        "@types/estree": "^1.0.6",
+        "@types/estree": "^1.0.8",
         "@types/json-schema": "^7.0.15",
         "@webassemblyjs/ast": "^1.14.1",
         "@webassemblyjs/wasm-edit": "^1.14.1",
         "@webassemblyjs/wasm-parser": "^1.14.1",
-        "acorn": "^8.14.0",
-        "browserslist": "^4.24.0",
+        "acorn": "^8.15.0",
+        "acorn-import-phases": "^1.0.3",
+        "browserslist": "^4.26.3",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.17.1",
+        "enhanced-resolve": "^5.17.3",
         "es-module-lexer": "^1.2.1",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -3313,11 +2780,11 @@
         "loader-runner": "^4.2.0",
         "mime-types": "^2.1.27",
         "neo-async": "^2.6.2",
-        "schema-utils": "^4.3.2",
-        "tapable": "^2.1.1",
+        "schema-utils": "^4.3.3",
+        "tapable": "^2.3.0",
         "terser-webpack-plugin": "^5.3.11",
-        "watchpack": "^2.4.1",
-        "webpack-sources": "^3.2.3"
+        "watchpack": "^2.4.4",
+        "webpack-sources": "^3.3.3"
       },
       "bin": {
         "webpack": "bin/webpack.js"
@@ -3401,18 +2868,18 @@
       }
     },
     "node_modules/webpack-sources": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.2.tgz",
-      "integrity": "sha512-ykKKus8lqlgXX/1WjudpIEjqsafjOTcOJqxnAbMLAu/KCsDCJ6GBtvscewvTkrn24HsnvFwrSCbenFrhtcCsAA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
+      "integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
       "peer": true,
       "engines": {
         "node": ">=10.13.0"
       }
     },
     "node_modules/wgsl_reflect": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/wgsl_reflect/-/wgsl_reflect-1.2.1.tgz",
-      "integrity": "sha512-PY6MdLqLW1NFj/V6f5/9/Nb4ultwlAF7lCLyjKOAkdnlf7LlrGXNFXzHHEV7Okg1zy4C4TpBIcc/G3PXW4py8g==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/wgsl_reflect/-/wgsl_reflect-1.2.3.tgz",
+      "integrity": "sha512-BQWBIsOn411M+ffBxmA6QRLvAOVbuz3Uk4NusxnqC1H7aeQcVLhdA3k2k/EFFFtqVjhz3z7JOOZF1a9hj2tv4Q==",
       "dev": true
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecoscope/ecoscope-deck-widgets",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "description": "Custom deck.gl components used by ecoscope",
   "main": "index.ts",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "ts-loader": "^9.5.2"
   },
   "devDependencies": {
-    "@deck.gl/core": "^9.1.14",
-    "@deck.gl/geo-layers": "^9.1.14",
-    "@deck.gl/layers": "^9.1.14",
-    "@deck.gl/widgets": "^9.1.14",
+    "@deck.gl/core": "^9.2.1",
+    "@deck.gl/geo-layers": "^9.2.1",
+    "@deck.gl/layers": "^9.2.1",
+    "@deck.gl/widgets": "^9.2.1",
     "css-loader": "^7.1.2",
     "style-loader": "^4.0.0",
     "webpack-cli": "^6.0.1"

--- a/src/widgets/legend.tsx
+++ b/src/widgets/legend.tsx
@@ -5,10 +5,15 @@ import {
 } from '@deck.gl/core';
 import './style.css'
 
+export type LegendValue = {
+  label: string;
+  color: string;
+}
+
 export type LegendWidgetProps = {
   id: string;
   title: string;
-  legend: Record<string, string>;
+  legendValues: Array<LegendValue>;
   placement: WidgetPlacement;
   style?: Partial<CSSStyleDeclaration>;
 }
@@ -43,7 +48,7 @@ export default class LegendWidget extends Widget<LegendWidgetProps> {
     const ul = document.createElement('ul');
     ul.classList.add('legend-labels');
 
-    Object.entries(this.props.legend).forEach(([label, color])=> {
+    this.props.legendValues.forEach(({label, color})=> {
       const li = document.createElement('li');
       const span = document.createElement('span');
 

--- a/src/widgets/legend.tsx
+++ b/src/widgets/legend.tsx
@@ -17,38 +17,24 @@ export type LegendWidgetProps = {
   id: string;
   title: string;
   legend: Legend;
-  placement?: WidgetPlacement;
-  style?: Partial<CSSStyleDeclaration>;
-  className?: string;
+  placement: WidgetPlacement;
 }
 
-export default class LegendWidget implements Widget<LegendWidgetProps> {
+export default class LegendWidget extends Widget<LegendWidgetProps> {
   id = 'legend';
-  props: LegendWidgetProps;
   placement: WidgetPlacement = 'bottom-right';
-  deck?: Deck;
-  element?: HTMLDivElement;
+  className: string = "ecoscope-legend-widget";
 
   constructor(props: LegendWidgetProps) {
-    this.id = props.id ?? 'legend';
-    this.placement = props.placement ?? 'bottom-right';
-    this.props = {
-      className: "deck-widget-legend",
-      ...props
-    };
-    this.props.style = this.props.style ?? {};
-    this.props.title = this.props.title ?? 'Legend';
+    super(props);
+    this.setProps(props);
   }
 
-  setProps(props: Partial<LegendWidgetProps>) {
-    Object.assign(this.props, props);
-  }
+  onRenderHTML(rootElement: HTMLElement): void {}
 
   onAdd({ deck }: { deck: Deck }): HTMLDivElement {
     const element = document.createElement('div');
     element.classList.add('deck-widget');
-    const {className} = this.props; 
-    if (className) element.classList.add(className);
 
     const titleElement = document.createElement('div');
     titleElement.innerText = this.props.title;
@@ -72,23 +58,9 @@ export default class LegendWidget implements Widget<LegendWidgetProps> {
     });
 
     legendElement.appendChild(ul);
-
-    const { style } = this.props;
-    if (style) {
-      Object.entries(style).map(([key, value]) => {
-        element.style.setProperty(key, value as string);
-      });
-    }
     element.appendChild(titleElement);
     element.appendChild(legendElement);
 
-    this.deck = deck;
-    this.element = element;
     return element;
-  }
-
-  onRemove() {
-    this.deck = undefined;
-    this.element = undefined;
   }
 }

--- a/src/widgets/legend.tsx
+++ b/src/widgets/legend.tsx
@@ -18,6 +18,7 @@ export type LegendWidgetProps = {
   title: string;
   legend: Legend;
   placement: WidgetPlacement;
+  style?: Partial<CSSStyleDeclaration>;
 }
 
 export default class LegendWidget extends Widget<LegendWidgetProps> {
@@ -34,7 +35,11 @@ export default class LegendWidget extends Widget<LegendWidgetProps> {
 
   onAdd({ deck }: { deck: Deck }): HTMLDivElement {
     const element = document.createElement('div');
-    element.classList.add('deck-widget');
+    element.classList.add('deck-widget', this.className);
+    Object.entries(this.props.style).map(([key, value]) => {
+      element.style.setProperty(key, value as string);
+    });
+  
 
     const titleElement = document.createElement('div');
     titleElement.innerText = this.props.title;

--- a/src/widgets/legend.tsx
+++ b/src/widgets/legend.tsx
@@ -5,18 +5,10 @@ import {
 } from '@deck.gl/core';
 import './style.css'
 
-export type LegendValue = {
-  label: string
-  color: string
-}
-export type Legend = {
-  values: Array<LegendValue>
-}
-
 export type LegendWidgetProps = {
   id: string;
   title: string;
-  legend: Legend;
+  legend: Record<string, string>;
   placement: WidgetPlacement;
   style?: Partial<CSSStyleDeclaration>;
 }
@@ -51,7 +43,7 @@ export default class LegendWidget extends Widget<LegendWidgetProps> {
     const ul = document.createElement('ul');
     ul.classList.add('legend-labels');
 
-    this.props.legend.values.forEach(({label, color}) => {
+    Object.entries(this.props.legend).forEach(([label, color])=> {
       const li = document.createElement('li');
       const span = document.createElement('span');
 

--- a/src/widgets/na-widget.tsx
+++ b/src/widgets/na-widget.tsx
@@ -18,7 +18,6 @@ export default class NorthArrowWidget extends Widget<NorthArrowWidgetProps>  {
   id = 'na-widget';
   placement: WidgetPlacement = 'top-left';
   viewports: {[id: string]: Viewport} = {};
-  element?: HTMLDivElement;
   className: string = "ecoscope-north-arrow-widget";
 
   constructor(props: NorthArrowWidgetProps) {
@@ -30,7 +29,6 @@ export default class NorthArrowWidget extends Widget<NorthArrowWidgetProps>  {
     const element = document.createElement('div');
     element.classList.add('deck-widget', this.className);
     this.deck = deck;
-    this.element = element;
     this.updateHTML();
     return element;
   }

--- a/src/widgets/na-widget.tsx
+++ b/src/widgets/na-widget.tsx
@@ -11,6 +11,7 @@ export type NorthArrowWidgetProps = {
   id?: string;
   placement?: WidgetPlacement;
   viewId?: string | null;
+  style?: Partial<CSSStyleDeclaration>;
 };
 
 
@@ -28,6 +29,9 @@ export default class NorthArrowWidget extends Widget<NorthArrowWidgetProps>  {
   onAdd({deck}) {    
     const element = document.createElement('div');
     element.classList.add('deck-widget', this.className);
+    Object.entries(this.props.style).map(([key, value]) => {
+        element.style.setProperty(key, value as string);
+    });
     this.deck = deck;
     this.updateHTML();
     return element;

--- a/src/widgets/na-widget.tsx
+++ b/src/widgets/na-widget.tsx
@@ -1,5 +1,4 @@
 import {
-  Deck,
   _GlobeViewport,
   Viewport,
   WebMercatorViewport,
@@ -10,66 +9,51 @@ import {render} from 'preact';
 
 export type NorthArrowWidgetProps = {
   id?: string;
-  className?: string;
   placement?: WidgetPlacement;
   viewId?: string | null;
 };
 
 
-export default class NorthArrowWidget implements Widget<NorthArrowWidgetProps>  {
+export default class NorthArrowWidget extends Widget<NorthArrowWidgetProps>  {
   id = 'na-widget';
-  props: NorthArrowWidgetProps;
   placement: WidgetPlacement = 'top-left';
-  viewId?: string | null = null;
-  deck?: Deck<any>;
   viewports: {[id: string]: Viewport} = {};
   element?: HTMLDivElement;
+  className: string = "ecoscope-north-arrow-widget";
 
   constructor(props: NorthArrowWidgetProps) {
-    this.id = props.id ?? 'na-widget';
-    this.placement = props.placement ?? 'top-left';
-    this.viewId = props.viewId ?? this.viewId;
-    this.props = {...props};
+    super(props);
+    this.setProps(props);
   }
 
-  onAdd({deck}) { 
-    const {className} = this.props;   
+  onAdd({deck}) {    
     const element = document.createElement('div');
-    element.classList.add('deck-widget', 'na-widget');
-    if (className) element.classList.add(className);
+    element.classList.add('deck-widget', this.className);
     this.deck = deck;
     this.element = element;
-    this.update();
+    this.updateHTML();
     return element;
   }
 
   setProps(props: Partial<NorthArrowWidgetProps>) {
     this.placement = props.placement ?? this.placement;
     this.viewId = props.viewId ?? this.viewId;
-    Object.assign(this.props, props);
-    this.update();
+    super.setProps(props);
   }
 
   onRedraw() {    
-    this.update();
+    this.updateHTML();
   }
 
   onViewportChange(viewport: Viewport) {    
     // no need to update if viewport is the same
     if (!viewport.equals(this.viewports[viewport.id])) {
       this.viewports[viewport.id] = viewport;
-      this.update();
+      this.updateHTML();
     }
   }
 
-
-  private update() {    
-
-    const element = this.element;
-    if (!element) {
-      return;
-    }
-
+  onRenderHTML(rootElement: HTMLElement): void {
     const viewId = this.viewId || Object.values(this.viewports)[0]?.id || 'default-view';
     const viewport = this.viewports[viewId];
 
@@ -89,7 +73,7 @@ export default class NorthArrowWidget implements Widget<NorthArrowWidgetProps>  
         </svg>
       </div>
     );
-    render(ui, element);
+    render(ui, rootElement);
   }
 
 

--- a/src/widgets/save-image.tsx
+++ b/src/widgets/save-image.tsx
@@ -10,74 +10,56 @@ interface SaveImageWidgetProps {
   id?: string;
   label?: string;
   placement?: WidgetPlacement;
-  style?: Partial<CSSStyleDeclaration>;
-  className?: string;
 }
 
-export default class SaveImageWidget implements Widget<SaveImageWidgetProps> {
+export default class SaveImageWidget extends Widget<SaveImageWidgetProps> {
   id = 'save-image';
-  props: SaveImageWidgetProps;
   placement: WidgetPlacement = 'top-right';
   viewId?: string | null = null;
-  deck?: Deck<any>;
-  element?: HTMLDivElement;
+  className: string = "ecoscope-scale-widget";
 
   constructor(props: SaveImageWidgetProps) {
-    this.id = props.id ?? 'save-image';
-    this.placement = props.placement ?? 'top-right';
     props.label = props.label ?? 'Save as Image';
-    props.style = props.style ?? {};
-    this.props = {...props};
+    super(props)
+    this.setProps(props);
   }
 
-  onAdd({ deck }: { deck: Deck<any> }): HTMLDivElement {
-    const { style, className } = this.props;
-    const element = document.createElement('div');
-    element.classList.add('deck-widget', 'deck-widget-save-image');
-    if (className) element.classList.add(className);
-    if (style) {
-      Object.entries(style).map(([key, value]) =>
-        element.style.setProperty(key, value as string),
-      );
-    }
-
+  onRenderHTML(rootElement: HTMLElement): void {
     const ui = (
-      <div className="deck-widget-button">
-        <button
-          className={`deck-widget-icon-button ${className}`}
-          type="button"
-          onClick={this.handleClick.bind(this)}
-          title={this.props.label}
-        >
-          <svg
-            fill="#000000"
-            version="1.1"
-            width="85%"
-            height="85%"
-            viewBox="0 0 492.676 492.676"
+      <div className={`deck-widget ${this.className}`}>
+        <div className="deck-widget-button">
+          <button
+            className={`deck-widget-icon-button`}
+            type="button"
+            onClick={this.handleClick.bind(this)}
+            title={this.props.label}
           >
-            <g>
+            <svg
+              fill="#000000"
+              version="1.1"
+              width="85%"
+              height="85%"
+              viewBox="0 0 492.676 492.676"
+            >
               <g>
-                <path
-                  d="M492.676,121.6H346.715l-23.494-74.789h-40.795H210.25h-40.794L145.961,121.6H0v324.266h492.676V121.6L492.676,121.6z
-                M246.338,415.533c-72.791,0-131.799-59.009-131.799-131.799c0-72.792,59.008-131.8,131.799-131.8s131.799,59.008,131.799,131.8
-                C378.137,356.525,319.129,415.533,246.338,415.533z"
-                />
-                <path
-                  d="M246.338,199.006c-46.72,0-84.728,38.008-84.728,84.729c0,46.72,38.008,84.728,84.728,84.728
-                c46.721,0,84.728-38.008,84.728-84.728C331.065,237.014,293.059,199.006,246.338,199.006z"
-                />
+                <g>
+                  <path
+                    d="M492.676,121.6H346.715l-23.494-74.789h-40.795H210.25h-40.794L145.961,121.6H0v324.266h492.676V121.6L492.676,121.6z
+                  M246.338,415.533c-72.791,0-131.799-59.009-131.799-131.799c0-72.792,59.008-131.8,131.799-131.8s131.799,59.008,131.799,131.8
+                  C378.137,356.525,319.129,415.533,246.338,415.533z"
+                  />
+                  <path
+                    d="M246.338,199.006c-46.72,0-84.728,38.008-84.728,84.729c0,46.72,38.008,84.728,84.728,84.728
+                  c46.721,0,84.728-38.008,84.728-84.728C331.065,237.014,293.059,199.006,246.338,199.006z"
+                  />
+                </g>
               </g>
-            </g>
-          </svg>
-        </button>
+            </svg>
+          </button>
+        </div>
       </div>
     );
-
-    this.deck = deck;
-    this.element = element;
-    render(ui, element);
-    return element;
+    render(ui, rootElement);
   }
 
   async handleClick() {
@@ -101,14 +83,5 @@ export default class SaveImageWidget implements Widget<SaveImageWidgetProps> {
           });
       }
     }
-  }
-
-  onRemove() {
-    this.deck = undefined;
-    this.element = undefined;
-  }
-
-  setProps(props: Partial<SaveImageWidgetProps>) {
-    Object.assign(this.props, props);
   }
 }

--- a/src/widgets/scale.tsx
+++ b/src/widgets/scale.tsx
@@ -17,39 +17,35 @@ export type ScaleWidgetProps = {
   useImperial?: boolean;
 }
 
-export default class ScaleWidget implements Widget<ScaleWidgetProps> {
+export default class ScaleWidget extends Widget<ScaleWidgetProps> {
   id = 'scale';
-  props: ScaleWidgetProps;
   placement: WidgetPlacement = 'bottom-left';
   viewId?: string | null = null;
   viewport?: Viewport;
-  deck?: Deck;
   element?: HTMLDivElement;
+  className: string = "ecoscope-scale-widget";
 
   constructor(props: ScaleWidgetProps) {
-    this.id = props.id ?? 'scale';
-    this.placement = props.placement ?? 'bottom-left';
-    this.viewId = props.viewId ?? null;
-    props.maxWidth = props.maxWidth ?? 300;
-    props.useImperial = props.useImperial ?? false;
-    props.style = props.style ?? {};
-    this.props = {...props};
+    super(props);
+    this.setProps(props);
   }
 
   setProps(props: Partial<ScaleWidgetProps>) {
-    Object.assign(this.props, props);
+    props.maxWidth = props.maxWidth ?? 300;
+    props.useImperial = props.useImperial ?? false;
+    props.style = props.style ?? {};
+    super.setProps(props);
   }
 
   onViewportChange(viewport: Viewport) {
     this.viewport = viewport;
-    this.update();
+    this.updateHTML();
   }
 
   onAdd({ deck }: { deck: Deck<any> }): HTMLDivElement {
-    const { style, className } = this.props;
+    const { style } = this.props;
     const element = document.createElement('div');
-    element.classList.add('deck-widget', 'deck-widget-scale');
-    if (className) element.classList.add(className);
+    element.classList.add('deck-widget', 'deck-widget-scale', this.className);
     if (style) {
       Object.entries(style).map(([key, value]) =>
         element.style.setProperty(key, value as string),
@@ -58,11 +54,11 @@ export default class ScaleWidget implements Widget<ScaleWidgetProps> {
     this.deck = deck;
     this.element = element;
 
-    this.update();
+    this.updateHTML();
     return element;
   }
 
-  update() {
+  onRenderHTML(rootElement: HTMLElement): void {
     if (this.viewport instanceof WebMercatorViewport) {
       const meters = this.viewport.metersPerPixel * this.props.maxWidth;
       let distance: number
@@ -86,10 +82,6 @@ export default class ScaleWidget implements Widget<ScaleWidgetProps> {
       distance = this.roundNumber(distance);
       const width = `${Math.round(this.props.maxWidth * ratio * (4 / 3))}px`;
 
-      const element = this.element;
-      if (!element) {
-        return;
-      }
       const ui = (
         <div>
           <svg id="test" style={{ width: width, height: "40px" }}>
@@ -139,7 +131,7 @@ export default class ScaleWidget implements Widget<ScaleWidgetProps> {
         </div>
       );
 
-      render(ui, element);
+      render(ui, rootElement);
     }
   }
 
@@ -150,10 +142,5 @@ export default class ScaleWidget implements Widget<ScaleWidgetProps> {
     d = d >= 10 ? 10 : d >= 5 ? 5 : d >= 3 ? 3 : d >= 2 ? 2 : 1;
 
     return pow10 * d;
-  }
-
-  onRemove() {
-    this.deck = undefined;
-    this.element = undefined;
   }
 }

--- a/src/widgets/scale.tsx
+++ b/src/widgets/scale.tsx
@@ -9,7 +9,6 @@ import {render} from 'preact';
 
 export type ScaleWidgetProps = {
   id?: string;
-  style?: Partial<CSSStyleDeclaration>;
   placement?: WidgetPlacement;
   viewId?: string | null;
   maxWidth?: number;
@@ -21,7 +20,6 @@ export default class ScaleWidget extends Widget<ScaleWidgetProps> {
   placement: WidgetPlacement = 'bottom-left';
   viewId?: string | null = null;
   viewport?: Viewport;
-  element?: HTMLDivElement;
   className: string = "ecoscope-scale-widget";
 
   constructor(props: ScaleWidgetProps) {
@@ -32,29 +30,12 @@ export default class ScaleWidget extends Widget<ScaleWidgetProps> {
   setProps(props: Partial<ScaleWidgetProps>) {
     props.maxWidth = props.maxWidth ?? 300;
     props.useImperial = props.useImperial ?? false;
-    props.style = props.style ?? {};
     super.setProps(props);
   }
 
   onViewportChange(viewport: Viewport) {
     this.viewport = viewport;
     this.updateHTML();
-  }
-
-  onAdd({ deck }: { deck: Deck<any> }): HTMLDivElement {
-    const { style } = this.props;
-    const element = document.createElement('div');
-    element.classList.add('deck-widget', 'deck-widget-scale', this.className);
-    if (style) {
-      Object.entries(style).map(([key, value]) =>
-        element.style.setProperty(key, value as string),
-      );
-    }
-    this.deck = deck;
-    this.element = element;
-
-    this.updateHTML();
-    return element;
   }
 
   onRenderHTML(rootElement: HTMLElement): void {

--- a/src/widgets/scale.tsx
+++ b/src/widgets/scale.tsx
@@ -10,7 +10,6 @@ import {render} from 'preact';
 export type ScaleWidgetProps = {
   id?: string;
   style?: Partial<CSSStyleDeclaration>;
-  className?: string;
   placement?: WidgetPlacement;
   viewId?: string | null;
   maxWidth?: number;

--- a/src/widgets/style.css
+++ b/src/widgets/style.css
@@ -1,4 +1,4 @@
-.deck-widget.deck-widget-title {
+.deck-widget.ecoscope-title-widget {
   font-size: 26px;
   font-style: normal;
   font-family: Helvetica;
@@ -15,7 +15,7 @@
   text-align: center;
 }
 
-.deck-widget.deck-widget-legend {
+.deck-widget.ecoscope-legend-widget {
   background-color: rgb(255, 255, 255);
   border-color: rgb(0, 0, 0);
   border-style: solid;

--- a/src/widgets/title.tsx
+++ b/src/widgets/title.tsx
@@ -10,63 +10,38 @@ export type TitleWidgetProps = {
   title: string;
   placement?: WidgetPlacement;
   style?: Partial<CSSStyleDeclaration>;
-  className?: string;
   placementX?: string;
   placementY?: string;
 }
 
-export default class TitleWidget implements Widget<TitleWidgetProps> {
+export default class TitleWidget extends Widget<TitleWidgetProps> {
   id = 'title';
-  props: TitleWidgetProps;
   placement: WidgetPlacement = 'fill';
-  deck?: Deck;
-  element?: HTMLDivElement;
+  className: string = "ecoscope-title-widget";
 
   constructor(props: TitleWidgetProps) {
-    this.id = props.id ?? 'title';
-    this.placement = props.placement ?? 'fill';
-    this.props = {
-      className: "deck-widget-title",
-      ...props
-    };
-    this.props.style = {
+    props.style = {
       position: "absolute",
       transform: "translate(-50%, -50%)",
       left: "50%",
       top: "1%",
       ...props.style ?? {},
     };
+    super(props);
+    this.setProps(props);
   }
 
-  setProps(props: Partial<TitleWidgetProps>) {
-    Object.assign(this.props, props);
-  }
+  onRenderHTML(rootElement: HTMLElement): void {}
 
   onAdd({ deck }: { deck: Deck }): HTMLDivElement {
     const element = document.createElement('div');
-
-    element.classList.add('deck-widget');
-    const {className} = this.props;   
-    if (className) element.classList.add(className);
-
+    element.classList.add('deck-widget', this.className);
+    Object.entries(this.props.style).map(([key, value]) => {
+      element.style.setProperty(key, value as string);
+    });
     const titleElement = document.createElement('div');
     titleElement.innerText = this.props.title;
-
-    const { style } = this.props;
-    if (style) {
-      Object.entries(style).map(([key, value]) => {
-        element.style.setProperty(key, value as string);
-      });
-    }
     element.appendChild(titleElement);
-
-    this.deck = deck;
-    this.element = element;
     return element;
-  }
-
-  onRemove() {
-    this.deck = undefined;
-    this.element = undefined;
   }
 }


### PR DESCRIPTION
## :earth_americas: Summary
closes #10 

## :package: Proposed Changes
- Reasonably big rework / clean up of widget code for 9.2 compatibility
  - Use updateHTML / onRenderHTML lifecycle methods instead of managing redraws ourselves
- Some tweaking of ClassNames attached to parent elements to make them a bit more intelligible
- Slight tweak of legend interface to remove an unnecessary type/property 