### PR TITLE
Support multiple headings in the legend widget

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ecoscope/ecoscope-deck-widgets",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ecoscope/ecoscope-deck-widgets",
-      "version": "0.0.5",
+      "version": "0.0.6",
       "license": "BSD-3-Clause",
       "dependencies": {
         "html-to-image": "^1.11.13",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ecoscope/ecoscope-deck-widgets",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "type": "module",
   "description": "Custom deck.gl components used by ecoscope",
   "main": "index.ts",

--- a/src/widgets/legend.tsx
+++ b/src/widgets/legend.tsx
@@ -13,7 +13,7 @@ export type LegendValue = {
 export type LegendWidgetProps = {
   id: string;
   title: string;
-  legendValues: Array<LegendValue>;
+  legendValues: Record<string, Array<LegendValue>>;
   placement: WidgetPlacement;
   style?: Partial<CSSStyleDeclaration>;
 }
@@ -37,32 +37,32 @@ export default class LegendWidget extends Widget<LegendWidgetProps> {
       element.style.setProperty(key, value as string);
     });
   
+    Object.entries(this.props.legendValues).map(([header, values])=> {    
+      const titleElement = document.createElement('div');
+      titleElement.innerText = header;
+      titleElement.classList.add('legend-title');
 
-    const titleElement = document.createElement('div');
-    titleElement.innerText = this.props.title;
-    titleElement.classList.add('legend-title');
+      const legendElement = document.createElement('div');
+      legendElement.classList.add('legend-scale');
 
-    const legendElement = document.createElement('div');
-    legendElement.classList.add('legend-scale');
+      const ul = document.createElement('ul');
+      ul.classList.add('legend-labels');
 
-    const ul = document.createElement('ul');
-    ul.classList.add('legend-labels');
+      values.forEach(({label, color})=> {        
+        const li = document.createElement('li');
+        const span = document.createElement('span');
 
-    this.props.legendValues.forEach(({label, color})=> {
-      const li = document.createElement('li');
-      const span = document.createElement('span');
+        span.style.setProperty('background', color);
+        li.innerText = label;
 
-      span.style.setProperty('background', color);
-      li.innerText = label;
+        li.appendChild(span);
+        ul.appendChild(li);
+      });
 
-      li.appendChild(span);
-      ul.appendChild(li);
+      legendElement.appendChild(ul);
+      element.appendChild(titleElement);
+      element.appendChild(legendElement);
     });
-
-    legendElement.appendChild(ul);
-    element.appendChild(titleElement);
-    element.appendChild(legendElement);
-
     return element;
   }
 }

--- a/src/widgets/legend.tsx
+++ b/src/widgets/legend.tsx
@@ -12,7 +12,6 @@ export type LegendValue = {
 
 export type LegendWidgetProps = {
   id: string;
-  title: string;
   legendValues: Record<string, Array<LegendValue>>;
   placement: WidgetPlacement;
   style?: Partial<CSSStyleDeclaration>;

--- a/src/widgets/legend.tsx
+++ b/src/widgets/legend.tsx
@@ -10,9 +10,14 @@ export type LegendValue = {
   color: string;
 }
 
+export type LegendSegment = {
+  title: string;
+  values: Array<LegendValue>;
+}
+
 export type LegendWidgetProps = {
   id: string;
-  legendValues: Record<string, Array<LegendValue>>;
+  legendValues: Array<LegendSegment>;
   placement: WidgetPlacement;
   style?: Partial<CSSStyleDeclaration>;
 }
@@ -36,9 +41,9 @@ export default class LegendWidget extends Widget<LegendWidgetProps> {
       element.style.setProperty(key, value as string);
     });
   
-    Object.entries(this.props.legendValues).map(([header, values])=> {    
+    this.props.legendValues.forEach(({title, values})=> {       
       const titleElement = document.createElement('div');
-      titleElement.innerText = header;
+      titleElement.innerText = title;
       titleElement.classList.add('legend-title');
 
       const legendElement = document.createElement('div');


### PR DESCRIPTION
## :earth_americas: Summary
Closes #15 

## :package: Proposed Changes
- Adds support for legend values as a list of title/list-of-values pair