### PR TITLE
Remove node auth token from publish flow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,5 +20,3 @@ jobs:
       - run: npm run lint
       - run: npm run build-webpack
       - run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## :earth_americas: Summary
Trusted publishing has been configured and token auth has been disabled, so updating the CI flow here in kind

## :package: Proposed Changes
- Removes the node auth token from publish flow