### PR TITLE
Add tooltip-widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,95 @@
 # ecoscope-deckgl-extensions
-Custom deck.gl widgets used by ecoscope
+
+Custom [deck.gl](https://deck.gl/) widgets and layers used by [Ecoscope](https://github.com/wildlife-dynamics/ecoscope). Built on `@deck.gl/core` 9.x and rendered with Preact. Bundled to a single UMD file (`dist/bundle.js`) that also attaches each export to `window` for embedding in non-bundled environments (e.g. notebook widgets).
+
+## Install
+
+```bash
+npm install @ecoscope/ecoscope-deckgl-extensions
+```
+
+```ts
+import {
+  NorthArrowWidget,
+  TitleWidget,
+  ScaleWidget,
+  LegendWidget,
+  SaveImageWidget,
+  TooltipWidget,
+  TiledBitmapLayer,
+} from '@ecoscope/ecoscope-deckgl-extensions';
+```
+
+## Widgets
+
+### `NorthArrowWidget`
+Compass SVG that rotates to match the current viewport. Reads `bearing`/`pitch` on a `WebMercatorViewport`.
+
+```ts
+new NorthArrowWidget({ placement: 'top-left' });
+```
+
+### `TitleWidget`
+Static title rendered as an absolutely-positioned overlay on the deck (this is to enable centering and positional overrides above the standard widget-placement quadrants).
+
+```ts
+new TitleWidget({ id: 'title', title: 'My Map' });
+```
+
+### `ScaleWidget`
+Two-block map scale bar. Computes distance from the viewport's `metersPerPixel`, and renders either as metric (`m`/`km`) or imperial (`ft`/`mi`) units.
+
+```ts
+new ScaleWidget({ maxWidth: 300, useImperial: false });
+```
+
+### `LegendWidget`
+Renders one or more legend segments, each with a title and a list of `{ label, color }` swatches.
+
+```ts
+new LegendWidget({
+  id: 'legend',
+  placement: 'bottom-right',
+  legendValues: [
+    { title: 'Species', values: [{ label: 'Elephant', color: '#aa3' }] },
+  ],
+});
+```
+
+### `SaveImageWidget`
+Toolbar button that snapshots the deck canvas and surrounding overlays (inclusive of other widgets) to PNG via `html-to-image` and triggers a `map.png` download. The button itself is filtered out of the capture.
+
+```ts
+new SaveImageWidget({ label: 'Save as Image' });
+```
+
+### `TooltipWidget`
+Installs a `getTooltip` handler on the deck that renders a feature's `properties` as an HTML table on hover. Pass `layerColumns` to whitelist which property keys to show per layer. This will override any existing tooltip on the deck it's added to. Exists to allow per layer definition of tooltip data via deck.gl json / Pydeck.
+
+```ts
+new TooltipWidget({
+  layerColumns: { 'subjects-layer': ['name', 'species'] },
+});
+```
+
+## Layers
+
+### `TiledBitmapLayer`
+A `TileLayer` that renders each tile as a `BitmapLayer`. When a tile finishes loading and a `widgetId` prop is set, it posts a `{ type: 'TileLoaded', widgetId }` message to `window.parent` — used to signal load completion to a host (e.g. a Jupyter widget iframe).
+Allows configuration of a simple tiled raster layer via deck.gl json / Pydeck.
+
+```ts
+new TiledBitmapLayer({
+  id: 'basemap',
+  data: 'https://tiles.example.com/{z}/{x}/{y}.png',
+  widgetId: 'map-1',
+});
+```
+
+## Development
+
+```bash
+npm run build-webpack   # bundle to dist/
+npm run typecheck
+npm run lint
+```

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,6 @@
-import { defineConfig } from 'eslint/config';
+import tseslint from 'typescript-eslint';
 
-export default tseslint.defineConfig(
+export default tseslint.config(
   ...tseslint.configs.recommended,
   {
     ignores: ['dist/'],

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,6 @@
-import tseslint from 'typescript-eslint';
+import { defineConfig } from 'eslint/config';
 
-export default tseslint.config(
+export default tseslint.defineConfig(
   ...tseslint.configs.recommended,
   {
     ignores: ['dist/'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import TitleWidget from './widgets/title';
 import ScaleWidget from './widgets/scale';
 import LegendWidget from './widgets/legend';
 import SaveImageWidget from './widgets/save-image';
+import TooltipWidget from './widgets/tooltip';
 import TiledBitmapLayer from './layers/tiled-bitmap-layer';
 
 export {default as NorthArrowWidget} from './widgets/na-widget'
@@ -10,6 +11,7 @@ export {default as TitleWidget} from './widgets/title'
 export {default as ScaleWidget} from './widgets/scale'
 export {default as LegendWidget} from './widgets/legend'
 export {default as SaveImageWidget} from './widgets/save-image';
+export {default as TooltipWidget} from './widgets/tooltip';
 export {default as TiledBitmapLayer} from './layers/tiled-bitmap-layer';
 
 const _global = (typeof window === 'undefined' ? global : window) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
@@ -18,4 +20,5 @@ _global.TitleWidget = {TitleWidget};
 _global.ScaleWidget = {ScaleWidget};
 _global.LegendWidget = {LegendWidget};
 _global.SaveImageWidget = {SaveImageWidget};
+_global.TooltipWidget = {TooltipWidget};
 _global.TiledBitmapLayer = {TiledBitmapLayer};

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,10 @@ export {default as TooltipWidget} from './widgets/tooltip';
 export {default as TiledBitmapLayer} from './layers/tiled-bitmap-layer';
 
 const _global = (typeof window === 'undefined' ? global : window) as any; // eslint-disable-line @typescript-eslint/no-explicit-any
-_global.NorthArrowWidget = {NorthArrowWidget};
-_global.TitleWidget = {TitleWidget};
-_global.ScaleWidget = {ScaleWidget};
-_global.LegendWidget = {LegendWidget};
-_global.SaveImageWidget = {SaveImageWidget};
-_global.TooltipWidget = {TooltipWidget};
-_global.TiledBitmapLayer = {TiledBitmapLayer};
+_global.NorthArrowWidget = NorthArrowWidget;
+_global.TitleWidget = TitleWidget;
+_global.ScaleWidget = ScaleWidget;
+_global.LegendWidget = LegendWidget;
+_global.SaveImageWidget = SaveImageWidget;
+_global.TooltipWidget = TooltipWidget;
+_global.TiledBitmapLayer = TiledBitmapLayer;

--- a/src/widgets/style.css
+++ b/src/widgets/style.css
@@ -58,3 +58,28 @@ ul.legend-labels li span {
   margin-left: 0;
   border: 1px solid #999;
 }
+
+/* 
+  Tooltip styling based on lonboard
+  https://github.com/developmentseed/lonboard/blob/main/src/tooltip/index.css
+*/
+.tooltip table {
+  border-collapse: collapse;
+}
+
+.tooltip table tr:nth-child(odd) {
+  background-color: #fff;
+}
+
+.tooltip table tr:nth-child(2n) {
+  background-color: #f1f1f1;
+}
+
+.tooltip td {
+  border: 1px solid rgb(204, 204, 204);
+  padding: 5px;
+}
+
+.tooltip td:first-child {
+  font-weight: 450;
+}

--- a/src/widgets/style.css
+++ b/src/widgets/style.css
@@ -63,23 +63,23 @@ ul.legend-labels li span {
   Tooltip styling based on lonboard
   https://github.com/developmentseed/lonboard/blob/main/src/tooltip/index.css
 */
-.tooltip table {
+.ecoscope-tooltip table {
   border-collapse: collapse;
 }
 
-.tooltip table tr:nth-child(odd) {
+.ecoscope-tooltip table tr:nth-child(odd) {
   background-color: #fff;
 }
 
-.tooltip table tr:nth-child(2n) {
+.ecoscope-tooltip table tr:nth-child(2n) {
   background-color: #f1f1f1;
 }
 
-.tooltip td {
+.ecoscope-tooltip td {
   border: 1px solid rgb(204, 204, 204);
   padding: 5px;
 }
 
-.tooltip td:first-child {
+.ecoscope-tooltip td:first-child {
   font-weight: 450;
 }

--- a/src/widgets/tooltip.tsx
+++ b/src/widgets/tooltip.tsx
@@ -1,0 +1,138 @@
+import {
+  Deck,
+  PickingInfo,
+  Widget,
+  WidgetPlacement,
+} from '@deck.gl/core';
+import './style.css';
+
+type LayerColumns = Record<string, string[] | null | undefined>;
+
+export type TooltipWidgetProps = {
+  id?: string;
+  // layer id → tooltip column names. A missing key (or null)
+  // means "show all properties" for that layer.
+  layerColumns?: LayerColumns;
+};
+
+const TOOLTIP_CLASS_NAME = 'tooltip';
+const TOOLTIP_STYLE: Partial<CSSStyleDeclaration> = {
+  backgroundColor: '#fff',
+  boxShadow: '0 0 15px rgba(0, 0, 0, 0.1)',
+  color: '#000',
+  padding: '6px',
+};
+
+export default class TooltipWidget extends Widget<TooltipWidgetProps> {
+  id = 'TooltipWidget';
+  // The widget API requires a placement but is superfluous here
+  placement: WidgetPlacement = 'fill';
+  layerColumns: LayerColumns = {};
+  className: string = "ecoscope-tooltip-widget";
+  // Install lazily from onRedraw (post-mount) instead,
+  // so we only buildTooltip once.
+  private _installed = false;
+
+  constructor(props: TooltipWidgetProps) {
+    super(props);
+    this.setProps(props);
+  }
+
+  setProps(props: Partial<TooltipWidgetProps>) {
+    this.layerColumns = props.layerColumns ?? this.layerColumns;
+    super.setProps(props);
+  }
+
+  onRenderHTML(_rootElement: HTMLElement): void {}
+
+  onAdd({ deck }: { deck: Deck }): HTMLDivElement {
+    this.deck = deck;
+    const element = document.createElement('div');
+    element.classList.add('deck-widget', this.className);
+    element.style.display = 'none';
+    return element;
+  }
+
+  onRedraw(): void {
+    if (!this._installed && this.deck) {
+      this._installed = true;
+      this.deck.setProps({
+        getTooltip: (info: PickingInfo) => buildTooltip(info, this.layerColumns),
+      });
+    }
+  }
+
+  onRemove(): void {
+    // Restore deck.gl's default (no tooltip) so the widget cleans up after itself.
+    if (this.deck) {
+      this.deck.setProps({ getTooltip: null });
+    }
+    this._installed = false;
+  }
+}
+
+type TooltipResult = {
+  className: string;
+  html: string;
+  style: Partial<CSSStyleDeclaration>;
+} | null;
+
+function buildTooltip(info: PickingInfo, layerColumns: LayerColumns): TooltipResult {
+  if (!info.object) return null;
+
+  // GeoJsonLayer hands us a Feature with `.properties`; raw record-backed
+  // layers (Scatterplot, Path, ...) hand us the row dict directly.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const properties: Record<string, any> | undefined =
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (info.object as any).properties ?? (info.object as Record<string, any>);
+  if (!properties || typeof properties !== 'object') return null;
+
+  const layerId = info.layer?.id;
+  const allowed = layerId ? layerColumns?.[layerId] : null;
+  const filterByAllowed = Array.isArray(allowed);
+
+  const rows: Array<[string, string]> = [];
+  for (const [key, value] of Object.entries(properties)) {
+    if (key === 'geometry') continue;
+    if (value === null || value === undefined || value === '') continue;
+    if (filterByAllowed && !allowed!.includes(key)) continue;
+    rows.push([key, formatValue(value)]);
+  }
+
+  if (rows.length === 0) return null;
+
+  const html = `<table><tbody>${rows
+    .map(
+      ([k, v]) =>
+        `<tr><td>${escapeHtml(k)}</td><td>${escapeHtml(v)}</td></tr>`,
+    )
+    .join('')}</tbody></table>`;
+
+  return {
+    className: TOOLTIP_CLASS_NAME,
+    html,
+    style: TOOLTIP_STYLE,
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function formatValue(value: any): string {
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+  return String(value);
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/src/widgets/tooltip.tsx
+++ b/src/widgets/tooltip.tsx
@@ -15,7 +15,7 @@ export type TooltipWidgetProps = {
   layerColumns?: LayerColumns;
 };
 
-const TOOLTIP_CLASS_NAME = 'tooltip';
+const TOOLTIP_CLASS_NAME = 'ecoscope-tooltip';
 const TOOLTIP_STYLE: Partial<CSSStyleDeclaration> = {
   backgroundColor: '#fff',
   boxShadow: '0 0 15px rgba(0, 0, 0, 0.1)',
@@ -27,20 +27,12 @@ export default class TooltipWidget extends Widget<TooltipWidgetProps> {
   id = 'TooltipWidget';
   // The widget API requires a placement but is superfluous here
   placement: WidgetPlacement = 'fill';
-  layerColumns: LayerColumns = {};
   className: string = "ecoscope-tooltip-widget";
-  // Install lazily from onRedraw (post-mount) instead,
-  // so we only buildTooltip once.
   private _installed = false;
 
   constructor(props: TooltipWidgetProps) {
     super(props);
     this.setProps(props);
-  }
-
-  setProps(props: Partial<TooltipWidgetProps>) {
-    this.layerColumns = props.layerColumns ?? this.layerColumns;
-    super.setProps(props);
   }
 
   onRenderHTML(_rootElement: HTMLElement): void {}
@@ -50,24 +42,14 @@ export default class TooltipWidget extends Widget<TooltipWidgetProps> {
     const element = document.createElement('div');
     element.classList.add('deck-widget', this.className);
     element.style.display = 'none';
-    return element;
-  }
 
-  onRedraw(): void {
     if (!this._installed && this.deck) {
       this._installed = true;
       this.deck.setProps({
-        getTooltip: (info: PickingInfo) => buildTooltip(info, this.layerColumns),
+        getTooltip: (info: PickingInfo) => buildTooltip(info, this.props.layerColumns),
       });
     }
-  }
-
-  onRemove(): void {
-    // Restore deck.gl's default (no tooltip) so the widget cleans up after itself.
-    if (this.deck) {
-      this.deck.setProps({ getTooltip: null });
-    }
-    this._installed = false;
+    return element;
   }
 }
 
@@ -79,9 +61,6 @@ type TooltipResult = {
 
 function buildTooltip(info: PickingInfo, layerColumns: LayerColumns): TooltipResult {
   if (!info.object) return null;
-
-  // GeoJsonLayer hands us a Feature with `.properties`; raw record-backed
-  // layers (Scatterplot, Path, ...) hand us the row dict directly.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const properties: Record<string, any> | undefined =
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -94,7 +73,6 @@ function buildTooltip(info: PickingInfo, layerColumns: LayerColumns): TooltipRes
 
   const rows: Array<[string, string]> = [];
   for (const [key, value] of Object.entries(properties)) {
-    if (key === 'geometry') continue;
     if (value === null || value === undefined || value === '') continue;
     if (filterByAllowed && !allowed!.includes(key)) continue;
     rows.push([key, formatValue(value)]);


### PR DESCRIPTION
## :earth_americas: Summary
Closes #23 

## :package: Proposed Changes
- Adds a tooltip widget intended to provide a way to define tooltip settings via deck json 
- Fleshes out the readme with a simple description of each class in this repo (at the time of writing)