### PR TITLE
Add provenvance flag to fix trusted publishing

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,4 +19,4 @@ jobs:
       - run: npm run typecheck
       - run: npm run lint
       - run: npm run build-webpack
-      - run: npm publish --access public
+      - run: npm publish --access public --provenance


### PR DESCRIPTION
## :earth_americas: Summary

## :package: Proposed Changes
Adds provenvance flag to (hopefully) fix trusted publishing