### PR TITLE
Bump to `node-version: 24` publish flow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run typecheck


### PR DESCRIPTION
## :earth_americas: Summary
Follow up to #26 - more trusted publishing fixes, bumping node to force a version of npm that supports trusted publishing

## :package: Proposed Changes
